### PR TITLE
add sparkthink tap to singer index

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,8 +142,8 @@ jobs:
         run: |
           cd docker
           poetry run tapdance build_image sparkthink snowflake-test --push $PRE_FLAG
-          poetry run tapdance build_image powerbi-metadata snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image dbt snowflake-test --push $PRE_FLAG
+          poetry run tapdance build_image powerbi-metadata snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image mssql snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image pardot snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image salesforce snowflake-test --push $PRE_FLAG

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           cd docker
           poetry run tapdance build_image powerbi-metadata snowflake-test --push $PRE_FLAG
+          poetry run tapdance build_image sparkthink snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image mssql snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image pardot snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image salesforce snowflake-test --push $PRE_FLAG

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -141,8 +141,9 @@ jobs:
       - name: Build and push all *prioritized* singer images (build number ${{ github.run_number }})
         run: |
           cd docker
-          poetry run tapdance build_image powerbi-metadata snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image sparkthink snowflake-test --push $PRE_FLAG
+          poetry run tapdance build_image dbt snowflake-test --push $PRE_FLAG
+          poetry run tapdance build_image powerbi-metadata snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image mssql snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image pardot snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image salesforce snowflake-test --push $PRE_FLAG

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,8 +142,8 @@ jobs:
         run: |
           cd docker
           poetry run tapdance build_image sparkthink snowflake-test --push $PRE_FLAG
-          poetry run tapdance build_image dbt snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image powerbi-metadata snowflake-test --push $PRE_FLAG
+          poetry run tapdance build_image dbt snowflake-test --push $PRE_FLAG
           poetry run tapdance build_image mssql snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image pardot snowflake-test --push $PRE_FLAG
         # poetry run tapdance build_image salesforce snowflake-test --push $PRE_FLAG

--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -40,7 +40,6 @@ singer-targets:
 
   # Custom forks with pending PRs:
   - { name: target-snowflake,  alias: target-snowflake-test, source: git+https://github.com/aaronsteers/pipelinewise-target-snowflake@feature/aaronsteers-retain-s3-files }
-  - { name: target-s3-csv,     alias: target-s3-csv-test,    source: git+https://github.com/aaronsteers/pipelinewise-target-s3-csv@feat/aws-access-token }
 
 failing-taps:
 

--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -26,6 +26,7 @@ singer-taps:
   - { name: tap-salesforce,  alias: tap-salesforce-pw, source: pipelinewise-tap-salesforce }
   - { name: tap-sftp }
   - { name: tap-snowflake,  source: pipelinewise-tap-snowflake }
+  - { name: tap-sparkthink, source: git+https://github.com/slalom/tap-sparkthink.git@main }
   - { name: tap-workday-raas }
   - { name: tap-zendesk }
 

--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -8,6 +8,7 @@
 singer-taps:
   - { name: tap-adwords }
   - { name: tap-covid-19 }
+  - { name: tap-dbt }
   - { name: tap-dynamodb,   source: git+https://github.com/aaronsteers/tap-dynamodb@master }
   - { name: tap-exchangeratesapi, source: git+https://github.com/aaronsteers/tap-exchangeratesapi@feature/discovery } # https://github.com/singer-io/tap-exchangeratesapi/pull/8
   - { name: tap-jira }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tapdance"
-version = "0.9.8"
+version = "0.9.9"
 description = "Tapdance is an orchestration layer for the open source Singer tap platform."
 authors = ["AJ Steers <aj.steers@slalom.com>"]
 license = "MIT"


### PR DESCRIPTION
We've created tap-sparkthink to hit the Sparkthink GraphQL endpoint and are ready to build pipelines using it
Adding it to singer index so that the tapdance docker image build process will create an image for the pipeline to use
We also included a reference to tap-dbt as that is a near term future project for us