### PR TITLE
Add Slalom pipelinewise s3 csv variant

### DIFF
--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -32,7 +32,7 @@ singer-taps:
   - { name: tap-zendesk }
 
   # Custom forks with pending PRs:
-  - { name: tap-s3-csv,      alias: tap-s3-csv-test, source: git+https://github.com/jtimeus-slalom/pipelinewise-tap-s3-csv@debug-table-config }
+  - { name: tap-s3-csv,      alias: tap-s3-csv-test, source: git+https://github.com/jtimeus-slalom/pipelinewise-tap-s3-csv@master }
 
 singer-targets:
   - { name: target-csv }

--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -31,6 +31,9 @@ singer-taps:
   - { name: tap-workday-raas }
   - { name: tap-zendesk }
 
+  # Custom forks with pending PRs:
+  - { name: tap-s3-csv,      alias: tap-s3-csv-test, source: git+https://github.com/jtimeus-slalom/pipelinewise-tap-s3-csv@accept-catalog-arg }
+
 singer-targets:
   - { name: target-csv }
   - { name: target-postgres,  source: pipelinewise-target-postgres }

--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -32,7 +32,7 @@ singer-taps:
   - { name: tap-zendesk }
 
   # Custom forks with pending PRs:
-  - { name: tap-s3-csv,      alias: tap-s3-csv-test, source: git+https://github.com/jtimeus-slalom/pipelinewise-tap-s3-csv@accept-catalog-arg }
+  - { name: tap-s3-csv,      alias: tap-s3-csv-test, source: git+https://github.com/jtimeus-slalom/pipelinewise-tap-s3-csv@debug-table-config }
 
 singer-targets:
   - { name: target-csv }


### PR DESCRIPTION
Add tap-s3-csv variant for slalom
variant accepts the catalog parameter, and handles tapdance passing a string in an environment variable that should be interpreted as a list