### PR TITLE
add ssh variant of tap-mysql to support Acquia

### DIFF
--- a/docker/singer_index.yml
+++ b/docker/singer_index.yml
@@ -34,6 +34,7 @@ singer-taps:
   - { name: tap-zendesk }
 
   # Custom forks with pending PRs:
+  - { name: tap-mysql,       alias: tap-mysql-ssh, source: git+https://github.com/mbaillergeon-slalom/pipelinewise-tap-mysql@master }
   - { name: tap-s3-csv,      alias: tap-s3-csv-test, source: git+https://github.com/jtimeus-slalom/pipelinewise-tap-s3-csv@master }
 
 singer-targets:


### PR DESCRIPTION
Acquia data is MySQL that is behind an SSH layer, this tap variant accepts SSH variables in the config to allow tunneling of the regular MySQL tap functionality